### PR TITLE
Fix mobile header overlap

### DIFF
--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -133,7 +133,7 @@
 
 .bodyOpen {
   /* margin: var(--headerHeight) auto 0; */
-  padding: 0;
+  padding: var(--headerHeight) 0 0 0;
   width: 80%;
   min-height: calc(100vh - var(--headerHeight));
   position: absolute;
@@ -145,7 +145,7 @@
 
 .bodyClosed {
   /* margin: var(--headerHeight) auto 0; */
-  padding: 0;
+  padding: var(--headerHeight) 0 0 0;
   width: 98%;
   min-height: calc(100vh - var(--headerHeight));
   position: absolute;
@@ -156,7 +156,7 @@
 
 .body {
   /* margin: var(--headerHeight) auto 0; */
-  padding: 0;
+  padding: var(--headerHeight) 0 0 0;
   width: 100%;
   height: 100%;
   background-color: var(--bg1);

--- a/styles/global.css
+++ b/styles/global.css
@@ -68,7 +68,10 @@ header {
 }
 
 
-main {min-height: 70vh;}
+main {
+  min-height: calc(100vh - var(--headerHeight));
+  padding-top: var(--headerHeight);
+}
 
 section {
   width: var(--container);


### PR DESCRIPTION
## Summary
- offset main content by header height
- adjust layout to add padding when header is fixed

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc88f0b6883279ee65b572df242e3